### PR TITLE
Update browser_action.css

### DIFF
--- a/src/css/browser_action.css
+++ b/src/css/browser_action.css
@@ -140,7 +140,8 @@ body {
     .container .stickCells .reviewers {
       width: 100%;
       display: inline-flex;
-      justify-content: flex-end; }
+      justify-content: flex-end;
+      flex-flow: row wrap; }
       .container .stickCells .reviewers .badgewrap {
         position: relative;
         margin-right: 5px; }


### PR DESCRIPTION
We have a lot of reviewers in our team, and the list forces a horizontal scrollbar in the extension tooltip. This change makes it jump on 2 lines.